### PR TITLE
package: Add repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "dnt-polyfill",
   "version": "1.0.0",
   "description": "Polyfill for DNT browser APIs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jhobz/dnt-polyfill"
+  },
   "main": "index.js",
   "scripts": {
     "test": "tape test.js"


### PR DESCRIPTION
This makes it so that https://www.npmjs.com/package/dnt-polyfill
points back to the repo. Right now the source code is not discoverable
other than to install it ad-hoc via the command line.